### PR TITLE
Get properties from parent class if exist extend in class declaration

### DIFF
--- a/tests/DtoPropertiesMapperTest.php
+++ b/tests/DtoPropertiesMapperTest.php
@@ -7,6 +7,7 @@ use Cerbero\Dto\Dtos\NoDocCommentDto;
 use Cerbero\Dto\Dtos\NoPropertiesDto;
 use Cerbero\Dto\Dtos\PartialDto;
 use Cerbero\Dto\Dtos\SampleDto;
+use Cerbero\Dto\Dtos\SampleDtoWithParent;
 use Cerbero\Dto\Exceptions\DtoNotFoundException;
 use Cerbero\Dto\Exceptions\InvalidDocCommentException;
 use Cerbero\Dto\Exceptions\MissingValueException;
@@ -23,7 +24,7 @@ class DtoPropertiesMapperTest extends TestCase
 {
     /**
      * This method is called before each test.
-     * 
+     *
      */
     protected function setUp(): void
     {
@@ -185,6 +186,42 @@ class DtoPropertiesMapperTest extends TestCase
         $this->assertCount(1, $types->all);
         $this->assertSame('Cerbero\Dto\SampleClass', $types->all[0]->name());
         $this->assertFalse($types->all[0]->isCollection());
+
+        $types = $map['name']->getTypes();
+        $this->assertInstanceOf(DtoPropertyTypes::class, $types);
+        $this->assertCount(1, $types->all);
+        $this->assertSame('string', $types->all[0]->name());
+        $this->assertFalse($types->all[0]->isCollection());
+
+        $types = $map['enabled']->getTypes();
+        $this->assertInstanceOf(DtoPropertyTypes::class, $types);
+        $this->assertCount(1, $types->all);
+        $this->assertSame('bool', $types->all[0]->name());
+        $this->assertFalse($types->all[0]->isCollection());
+    }
+
+    /**
+     * @test
+     */
+    public function maps_with_parent_properties()
+    {
+        $data = [
+            'name' => 'foo',
+            'enabled' => true,
+        ];
+
+        $names = array_keys($data);
+        $map = DtoPropertiesMapper::for(SampleDtoWithParent::class)->map($data, NONE);
+
+        $this->assertCount(2, $map);
+
+        foreach ($map as $name => $propery) {
+            $this->assertContains($name, $names);
+            $this->assertInstanceOf(DtoProperty::class, $propery);
+            $this->assertSame($name, $propery->getName());
+            $this->assertSame($data[$name], $propery->getRawValue());
+            $this->assertSame(NONE, $propery->getFlags());
+        }
 
         $types = $map['name']->getTypes();
         $this->assertInstanceOf(DtoPropertyTypes::class, $types);

--- a/tests/Dtos/SampleDtoWithParent.php
+++ b/tests/Dtos/SampleDtoWithParent.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Cerbero\Dto\Dtos;
+
+use Cerbero\Dto\Dto;
+use Cerbero\Dto\SampleClass;
+
+/**
+ * Sample DTO.
+ *
+ * @property-read string $name
+ */
+class SampleDtoWithParent extends SampleParentDto
+{
+    //
+}

--- a/tests/Dtos/SampleParentDto.php
+++ b/tests/Dtos/SampleParentDto.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Cerbero\Dto\Dtos;
+
+use Cerbero\Dto\Dto;
+use Cerbero\Dto\SampleClass;
+
+/**
+ * Sample DTO.
+ *
+ * @property-read bool $enabled
+ */
+class SampleParentDto extends Dto
+{
+    //
+}


### PR DESCRIPTION
## Description

When DTOs has reusable attribute it is more logical move it into a separate DTO class and make inheritance.

## Motivation and context

In my projects i have requests there are attributes that are present in every API request.
In order not to write these attributes in each DTO, I moved them to a separate extend class

## How has this been tested?
I wrote a phpunit test method to test this feature
method is maps_with_parent_properties() in DtoPropertiesMapperTest class

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
