### PR TITLE
Improvements for PHP 8.1

### DIFF
--- a/src/Dto.php
+++ b/src/Dto.php
@@ -39,6 +39,23 @@ abstract class Dto implements IteratorAggregate, ArrayAccess, Serializable, Json
     }
 
     /**
+     * @return string
+     */
+    public function __serialize()
+    {
+        return $this->serialize();
+    }
+
+    /**
+     * @param mixed $serialized
+     * @return string
+     */
+    public function __unserialize($serialized)
+    {
+        return $this->unserialize($serialized);
+    }
+
+    /**
      * Retrieve an instance of DTO
      *
      * @param array $data

--- a/src/Traits/TurnsIntoArray.php
+++ b/src/Traits/TurnsIntoArray.php
@@ -64,6 +64,7 @@ trait TurnsIntoArray
      * @return mixed
      * @throws UnknownDtoPropertyException
      */
+    #[\ReturnTypeWillChange]
     public function &offsetGet($property)
     {
         $value = $this->get($property);


### PR DESCRIPTION
As of PHP 8.1.0, a class which implements Serializable without also implementing `__serialize()` and `__unserialize()` will generate a deprecation warning.

Also return type of & Cerbero\Dto\Dto::offsetGet($property) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice